### PR TITLE
Add PR trigger and guard pages deployment

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
     - main
+  pull_request:
+    branches:
+    - main
 
 # This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
@@ -50,6 +53,7 @@ jobs:
 
     # Push the book's HTML to github-pages
     - name: GitHub Pages action
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add a pull request trigger for the workflow targeting the main branch
- ensure the GitHub Pages deployment step runs only on pushes to main

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e58366040c8330a8a4cedd490ad9ed