### PR TITLE
Update of README.md links (NiTransforms and Pixi)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ Binder sessions can take a few minutes to start and reset after inactivity.
 This repository is configured with [pixi](https://prefix.dev/pixi) for
 reproducible environments:
 
-1. [Install pixi](https://prefix.dev/docs/pixi/installation).
+1. [Install pixi](https://pixi.sh/latest/installation/).
 2. Create the environment and install the dependencies:
 
    ```bash
    pixi install
    ```
+
 3. Build the static HTML version of the book:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 NiPreps Book is a [Jupyter Book](https://jupyterbook.org) that accompanies the NiPreps
 community workshops. The material walks readers through implementing a
 head-motion–correction workflow for diffusion MRI (dMRI) data using tools from
-[DIPY](https://dipy.org), [NiTransforms](https://nipy.org/nitransforms), and the
+[DIPY](https://dipy.org), [NiTransforms](https://nitransforms.readthedocs.io/en/latest/), and the
 broader NiPreps ecosystem. Besides explaining the motivation behind the
 "analysis-grade" data philosophy, the book provides hands-on notebooks that show
 how to assemble reproducible preprocessing components.
@@ -21,7 +21,7 @@ Binder sessions can take a few minutes to start and reset after inactivity.
 
 ### Build the book locally
 
-This repository is configured with [pixi](https://prefix.dev/pixi) for
+This repository is configured with [pixi](https://pixi.sh/latest/) for
 reproducible environments:
 
 1. [Install pixi](https://pixi.sh/latest/installation/).


### PR DESCRIPTION
In this pr I updated the links which were redirecting to a 404 page inside the README.md file

Here is a table summarizing the changes

| Original link | Updated link |
| -------- | -------- |
| [NiTransforms](https://nipy.org/nitransforms) | [NiTransforms](https://nitransforms.readthedocs.io/en/latest/) |
[pixi](https://prefix.dev/pixi) | [pixi](https://pixi.sh/latest/) |
[Install pixi](https://prefix.dev/docs/pixi/installation) | [Install pixi](https://pixi.sh/latest/installation/)

Let me know if you have any question or remark

Have a good day